### PR TITLE
Lee - test case on rte_classifier and call_tadm

### DIFF
--- a/nltk/classify/rte_classify_testCase_version.py
+++ b/nltk/classify/rte_classify_testCase_version.py
@@ -1,0 +1,209 @@
+# Natural Language Toolkit: RTE Classifier
+#
+# Copyright (C) 2001-2023 NLTK Project
+# Author: Ewan Klein <ewan@inf.ed.ac.uk>
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""
+Simple classifier for RTE corpus.
+
+It calculates the overlap in words and named entities between text and
+hypothesis, and also whether there are words / named entities in the
+hypothesis which fail to occur in the text, since this is an indicator that
+the hypothesis is more informative than (i.e not entailed by) the text.
+
+TO DO: better Named Entity classification
+TO DO: add lemmatization
+"""
+
+from nltk.classify.maxent import MaxentClassifier
+from nltk.classify.util import accuracy
+from nltk.tokenize import RegexpTokenizer
+
+branch_coverage = {
+    "branch_if_sample_N_not_none": False,
+    "branch_else_sample_N_none": False,
+    "branch_if_algorithm_megam": False,
+    "branch_elif_algorithm_GIS_IIS": False,
+    "branch_else_algorithm_error": False
+}
+
+class RTEFeatureExtractor:
+    """
+    This builds a bag of words for both the text and the hypothesis after
+    throwing away some stopwords, then calculates overlap and difference.
+    """
+
+    def __init__(self, rtepair, stop=True, use_lemmatize=False):
+        """
+        :param rtepair: a ``RTEPair`` from which features should be extracted
+        :param stop: if ``True``, stopwords are thrown away.
+        :type stop: bool
+        """
+        self.stop = stop
+        self.stopwords = {
+            "a",
+            "the",
+            "it",
+            "they",
+            "of",
+            "in",
+            "to",
+            "is",
+            "have",
+            "are",
+            "were",
+            "and",
+            "very",
+            ".",
+            ",",
+        }
+
+        self.negwords = {"no", "not", "never", "failed", "rejected", "denied"}
+        # Try to tokenize so that abbreviations, monetary amounts, email
+        # addresses, URLs are single tokens.
+        tokenizer = RegexpTokenizer(r"[\w.@:/]+|\w+|\$[\d.]+")
+
+        # Get the set of word types for text and hypothesis
+        self.text_tokens = tokenizer.tokenize(rtepair.text)
+        self.hyp_tokens = tokenizer.tokenize(rtepair.hyp)
+        self.text_words = set(self.text_tokens)
+        self.hyp_words = set(self.hyp_tokens)
+
+        if use_lemmatize:
+            self.text_words = {self._lemmatize(token) for token in self.text_tokens}
+            self.hyp_words = {self._lemmatize(token) for token in self.hyp_tokens}
+
+        if self.stop:
+            self.text_words = self.text_words - self.stopwords
+            self.hyp_words = self.hyp_words - self.stopwords
+
+        self._overlap = self.hyp_words & self.text_words
+        self._hyp_extra = self.hyp_words - self.text_words
+        self._txt_extra = self.text_words - self.hyp_words
+
+    def overlap(self, toktype, debug=False):
+        """
+        Compute the overlap between text and hypothesis.
+
+        :param toktype: distinguish Named Entities from ordinary words
+        :type toktype: 'ne' or 'word'
+        """
+        ne_overlap = {token for token in self._overlap if self._ne(token)}
+        if toktype == "ne":
+            if debug:
+                print("ne overlap", ne_overlap)
+            return ne_overlap
+        elif toktype == "word":
+            if debug:
+                print("word overlap", self._overlap - ne_overlap)
+            return self._overlap - ne_overlap
+        else:
+            raise ValueError("Type not recognized:'%s'" % toktype)
+
+    def hyp_extra(self, toktype, debug=True):
+        """
+        Compute the extraneous material in the hypothesis.
+
+        :param toktype: distinguish Named Entities from ordinary words
+        :type toktype: 'ne' or 'word'
+        """
+        ne_extra = {token for token in self._hyp_extra if self._ne(token)}
+        if toktype == "ne":
+            return ne_extra
+        elif toktype == "word":
+            return self._hyp_extra - ne_extra
+        else:
+            raise ValueError("Type not recognized: '%s'" % toktype)
+
+    @staticmethod
+    def _ne(token):
+        """
+        This just assumes that words in all caps or titles are
+        named entities.
+
+        :type token: str
+        """
+        if token.istitle() or token.isupper():
+            return True
+        return False
+
+    @staticmethod
+    def _lemmatize(word):
+        """
+        Use morphy from WordNet to find the base form of verbs.
+        """
+        from nltk.corpus import wordnet as wn
+
+        lemma = wn.morphy(word, pos=wn.VERB)
+        if lemma is not None:
+            return lemma
+        return word
+
+
+def rte_features(rtepair):
+    extractor = RTEFeatureExtractor(rtepair)
+    features = {}
+    features["alwayson"] = True
+    features["word_overlap"] = len(extractor.overlap("word"))
+    features["word_hyp_extra"] = len(extractor.hyp_extra("word"))
+    features["ne_overlap"] = len(extractor.overlap("ne"))
+    features["ne_hyp_extra"] = len(extractor.hyp_extra("ne"))
+    features["neg_txt"] = len(extractor.negwords & extractor.text_words)
+    features["neg_hyp"] = len(extractor.negwords & extractor.hyp_words)
+    return features
+
+
+def rte_featurize(rte_pairs):
+    return [(rte_features(pair), pair.value) for pair in rte_pairs]
+
+
+def rte_classifier(algorithm, sample_N=None):
+    from nltk.corpus import rte as rte_corpus
+
+    train_set = rte_corpus.pairs(["rte1_dev.xml", "rte2_dev.xml", "rte3_dev.xml"])
+    test_set = rte_corpus.pairs(["rte1_test.xml", "rte2_test.xml", "rte3_test.xml"])
+
+    if sample_N is not None:
+        branch_coverage["branch_if_sample_N_not_none"] = True
+        train_set = train_set[:sample_N]
+        test_set = test_set[:sample_N]
+    else:
+        
+        branch_coverage["branch_else_sample_N_none"] = True
+
+    featurized_train_set = rte_featurize(train_set)
+    featurized_test_set = rte_featurize(test_set)
+
+    # Train the classifier
+    print("Training classifier...")
+    if algorithm in ["megam"]:  # MEGAM based algorithms.
+        branch_coverage["branch_if_algorithm_megam"] = True
+        clf = MaxentClassifier.train(featurized_train_set, algorithm)
+    elif algorithm in ["GIS", "IIS"]:  # Use default GIS/IIS MaxEnt algorithm
+        branch_coverage["branch_elif_algorithm_GIS_IIS"] = True
+        clf = MaxentClassifier.train(featurized_train_set, algorithm)
+    else:
+        branch_coverage["branch_else_algorithm_error"] = True
+        err_msg = str(
+            "RTEClassifier only supports these algorithms:\n "
+            "'megam', 'GIS', 'IIS'.\n"
+        )
+        raise Exception(err_msg)
+    print("Testing classifier...")
+    acc = accuracy(clf, featurized_test_set)
+    print("Accuracy: %6.4f" % acc)
+    return clf
+
+def print_coverage():
+    total_branches = len(branch_coverage)
+    covered_branches = sum(1 for covered in branch_coverage.values() if covered)
+    coverage_percentage = (covered_branches / total_branches) * 100
+    print(f"Branch Coverage: {coverage_percentage:.2f}% ({covered_branches}/{total_branches} branches covered)")
+    for branch, hit in branch_coverage.items():
+        print(f"{branch} was {'hit' if hit else 'not hit'}")
+        
+def reset_coverage():
+    for key in branch_coverage.keys():
+        branch_coverage[key] = False

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -18,11 +18,11 @@ except ImportError:
 _tadm_bin = None
 
 branch_coverage = {
-    "call_tadm_args_typeError": False,  # Branch for checking if args is a string
+    "call_tadm_args_typeError": False,
     "call_tadm_args_typeMatched": False,
-    "call_tadm_tadm_bin_none": False,  # Branch for checking if _tadm_bin is None
+    "call_tadm_tadm_bin_none": False,
     "call_tadm_tadm_bin_NOT_none": False,
-    "call_tadm_failure": False, # Branch for subprocess failure
+    "call_tadm_failure": False,
     "call_tadm_success": False
 }
 
@@ -152,77 +152,6 @@ if __name__ == "__main__":
     encoding_demo()
     names_demo()
     
-def test_call_tadm_typeError_T():
-    reset_coverage()
-    try:
-        call_tadm("hello")
-    except Exception as e:
-        print(e)
-    
-    assert(branch_coverage["call_tadm_args_typeError"] == True)
-
-    print("test_call_tadm_typeError_T")
-    print_coverage()
-
-    print("------------")
-    
-def test_call_tadm_typeMatched_bin_None():
-    reset_coverage()
-    try:
-        call_tadm(["hello"])
-    except Exception as e:
-        print(f"Test failed: {e}")
-        
-    assert(branch_coverage["call_tadm_args_typeMatched"] == True)
-    assert(branch_coverage["call_tadm_tadm_bin_none"] == True)
-        
-    print("test_call_tadm_typeMatched_bin_None")
-    print_coverage()
-
-    print("------------")
-    
-def test_call_tadm_bin_NOT_None_Failure():
-    reset_coverage()
+def test_tadm_bin_generator(path):
     global _tadm_bin
-    _tadm_bin = "/bin/ls"
-    try:
-        call_tadm(["/nonexistent_directory"])
-    except OSError as e:
-        print(f"Error: {e}")
-        
-    assert(branch_coverage["call_tadm_args_typeMatched"] == True)
-    assert(branch_coverage["call_tadm_tadm_bin_NOT_none"] == True)
-    assert(branch_coverage["call_tadm_failure"] == True)
-    
-
-    print("test_call_tadm_bin_NOT_None_Failure")
-    print_coverage()
-    
-    print("------------")
-    
-def test_call_tadm_bin_NOT_None_Success():
-    reset_coverage()
-    global _tadm_bin
-    _tadm_bin = "/bin/echo" 
-    try:
-        call_tadm(["hello"])
-    except Exception as e:
-        print(f"Test failed: {e}")
-    
-    assert(branch_coverage["call_tadm_args_typeMatched"] == True)
-    assert(branch_coverage["call_tadm_tadm_bin_NOT_none"] == True)
-    assert(branch_coverage["call_tadm_success"] == True)
-
-    print("test_call_tadm_bin_NOT_None_Success")
-    print_coverage()
-    
-    print("------------")
-    
-def run_testAll():
-    test_call_tadm_typeError_T()
-    test_call_tadm_typeMatched_bin_None()
-    test_call_tadm_bin_NOT_None_Failure()
-    test_call_tadm_bin_NOT_None_Success()
-    
-run_testAll()
-
+    _tadm_bin = path

--- a/nltk/test/unit/test_call_tadm.py
+++ b/nltk/test/unit/test_call_tadm.py
@@ -31,7 +31,7 @@ class TestCallTadm(unittest.TestCase):
         print("test_call_tadm_typeMatched_bin_None")
         test_tadm_bin_generator(None)
         try:
-            call_tadm(["hi"])
+            call_tadm(["hello"])
             print_coverage()
         except Exception as e:
             print_coverage()
@@ -44,11 +44,13 @@ class TestCallTadm(unittest.TestCase):
     def test_call_tadm_bin_NOT_None_Failure(self):
         print("test_call_tadm_bin_NOT_None_Failure")
         test_tadm_bin_generator("/bin/ls")
-        try:
-            call_tadm(["/nonexistent_directory"])
-            print_coverage()
-        except Exception:
-            print_coverage()
+        expected_stderr = "ls: cannot access '/nonexistent_directory': No such file or directory\n"
+        
+        with self.assertRaises(Exception):
+            stdout, stderr = call_tadm(["/nonexistent_directory"])
+            self.assertEqual(stderr, expected_stderr)
+            
+        print_coverage()
 
         self.assertTrue(branch_coverage["call_tadm_args_typeMatched"])
         self.assertTrue(branch_coverage["call_tadm_tadm_bin_NOT_none"])
@@ -59,8 +61,12 @@ class TestCallTadm(unittest.TestCase):
     def test_call_tadm_bin_NOT_None_Success(self):
         print("test_call_tadm_bin_NOT_None_Success")
         test_tadm_bin_generator("/bin/echo" )
+        expected_stdout = "hello\n"
+        
         try:
-            call_tadm(["hello"])
+            stdout, stderr = call_tadm(["hello"])
+            self.assertEqual(stdout, expected_stdout)
+            self.assertEqual(stderr, "")
             print_coverage()
         except Exception as e:
             print_coverage()

--- a/nltk/test/unit/test_call_tadm.py
+++ b/nltk/test/unit/test_call_tadm.py
@@ -1,0 +1,76 @@
+
+import unittest
+import sys
+import os
+
+module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '/Users/junlee/sep/nltk_SEP_group120/nltk'))
+sys.path.insert(0, module_path)
+
+from classify.tadm import call_tadm, branch_coverage, print_coverage, reset_coverage, test_tadm_bin_generator
+
+class TestCallTadm(unittest.TestCase):
+
+    def setUp(self):
+        reset_coverage()
+        global _tadm_bin
+        _tadm_bin = None
+    
+    def test_call_tadm_typeError_T(self):
+        print("test_call_tadm_typeError_T")
+        try:
+            call_tadm("hello")
+            print_coverage()
+        except Exception as e:
+            print_coverage()
+        
+        self.assertTrue(branch_coverage["call_tadm_args_typeError"])
+        
+        print("------------")
+
+    def test_call_tadm_typeMatched_bin_None(self):
+        print("test_call_tadm_typeMatched_bin_None")
+        test_tadm_bin_generator(None)
+        try:
+            call_tadm(["hi"])
+            print_coverage()
+        except Exception as e:
+            print_coverage()
+
+        self.assertTrue(branch_coverage["call_tadm_args_typeMatched"])
+        self.assertTrue(branch_coverage["call_tadm_tadm_bin_none"])
+        
+        print("------------")
+
+    def test_call_tadm_bin_NOT_None_Failure(self):
+        print("test_call_tadm_bin_NOT_None_Failure")
+        test_tadm_bin_generator("/bin/ls")
+        try:
+            call_tadm(["/nonexistent_directory"])
+            print_coverage()
+        except Exception:
+            print_coverage()
+
+        self.assertTrue(branch_coverage["call_tadm_args_typeMatched"])
+        self.assertTrue(branch_coverage["call_tadm_tadm_bin_NOT_none"])
+        self.assertTrue(branch_coverage["call_tadm_failure"])
+        
+        print("------------")
+
+    def test_call_tadm_bin_NOT_None_Success(self):
+        print("test_call_tadm_bin_NOT_None_Success")
+        test_tadm_bin_generator("/bin/echo" )
+        try:
+            call_tadm(["hello"])
+            print_coverage()
+        except Exception as e:
+            print_coverage()
+
+        self.assertTrue(branch_coverage["call_tadm_args_typeMatched"])
+        self.assertTrue(branch_coverage["call_tadm_tadm_bin_NOT_none"])
+        self.assertTrue(branch_coverage["call_tadm_success"])
+        
+        print("------------")
+   
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nltk/test/unit/test_rte_classifier.py
+++ b/nltk/test/unit/test_rte_classifier.py
@@ -3,12 +3,12 @@ import unittest
 import sys
 import os
 
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '/Users/junlee/nltk/nltk'))
+module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '/Users/junlee/sep/nltk_SEP_group120/nltk'))
 sys.path.insert(0, module_path)
 
 from nltk import config_megam
 
-from classify.rte_classify import rte_classifier, branch_coverage, print_coverage, reset_coverage
+from classify.rte_classify_testCase_version import rte_classifier, branch_coverage, print_coverage, reset_coverage
 from nltk.corpus import rte as rte_corpus
 
 
@@ -33,15 +33,16 @@ class TestRTEClassifierOnly(unittest.TestCase):
     
     def test_rte_classification_with_megam(self):
         try:
-            config_megam()  # This configures and checks for the megam binary
-        except LookupError:
-            self.skipTest("megam binary not available")
-   
-        clf = rte_classifier("megam", sample_N=100)
+            clf = rte_classifier("megam", sample_N=100)
+            print("test_rte_classification_with_megam")
+            print_coverage()
+        except Exception as e:
+            print(e)
+            print("test_rte_classification_with_megam")
+            print_coverage()
+            
         self.assertTrue(branch_coverage["branch_if_sample_N_not_none"])
         self.assertTrue(branch_coverage["branch_if_algorithm_megam"])
-        print("test_rte_classification_with_megam")
-        print_coverage()
 
         
     # above test completes 3 out of 5 branches thus adding two extra to fullfil 100%

--- a/nltk/test/unit/test_rte_classifier.py
+++ b/nltk/test/unit/test_rte_classifier.py
@@ -1,0 +1,69 @@
+
+import unittest
+import sys
+import os
+
+module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '/Users/junlee/nltk/nltk'))
+sys.path.insert(0, module_path)
+
+from nltk import config_megam
+
+from classify.rte_classify import rte_classifier, branch_coverage, print_coverage, reset_coverage
+from nltk.corpus import rte as rte_corpus
+
+
+class TestRTEClassifierOnly(unittest.TestCase):
+
+    def setUp(self):
+        reset_coverage()
+    
+    def test_rte_classification_without_megam(self):
+        # Use a sample size for unit testing, since we
+        # don't need to fully train these classifiers
+        try:
+            clf = rte_classifier("IIS", sample_N=100)
+            clf = rte_classifier("GIS", sample_N=100)
+            self.assertTrue(branch_coverage["branch_if_sample_N_not_none"])
+            self.assertTrue(branch_coverage["branch_elif_algorithm_GIS_IIS"])
+            print("test_rte_classification_without_megam")
+            print_coverage()
+        except Exception as e:
+            print(e)
+            print_coverage()
+    
+    def test_rte_classification_with_megam(self):
+        try:
+            config_megam()  # This configures and checks for the megam binary
+        except LookupError:
+            self.skipTest("megam binary not available")
+   
+        clf = rte_classifier("megam", sample_N=100)
+        self.assertTrue(branch_coverage["branch_if_sample_N_not_none"])
+        self.assertTrue(branch_coverage["branch_if_algorithm_megam"])
+        print("test_rte_classification_with_megam")
+        print_coverage()
+
+        
+    # above test completes 3 out of 5 branches thus adding two extra to fullfil 100%
+    
+    def test_rte_classification_sampleN_None(self):
+        
+        clf = rte_classifier("GIS", None)
+        self.assertTrue(branch_coverage["branch_else_sample_N_none"])
+        self.assertTrue(branch_coverage["branch_elif_algorithm_GIS_IIS"])
+        print("test_rte_classification_sampleN_None")
+        print_coverage()
+            
+        
+    def test_rte_classification_unsupported_algorithm(self):
+        
+        with self.assertRaises(Exception):
+            clf = rte_classifier("ALGO", sample_N=100)
+        self.assertTrue(branch_coverage["branch_if_sample_N_not_none"])
+        self.assertTrue(branch_coverage["branch_else_algorithm_error"])
+        print("test_rte_classification_unsupported_algorithm")
+        print_coverage()
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
quick heads up that there are two files existing for rte_classify.py and rte_cclassify_testCase_verson.py.

Technically, these two difference is that classify.py holds its unstructured old test cases that i created in the beginning so created old copy of rte_classify_testCase_version.py so that latest unittest of test_rte_classifier works correctly.

** Also do not get confuse between test_rte_classify and test_rte_classifier as classify test is existing test that covers more than a classifier **

so in terminal, change directory to test and then unit. 
Run python -m unittest test_rte_classifier.py  will print out the branch coverage of rte_classifier.